### PR TITLE
Fix messages endpoint

### DIFF
--- a/src/mcp_proxy/mcp_server.py
+++ b/src/mcp_proxy/mcp_server.py
@@ -98,7 +98,7 @@ def create_single_instance_routes(
     """Create Starlette routes and the HTTP session manager for a single MCP server instance."""
     logger.debug("Creating routes for a single MCP server instance (stateless: %s)", stateless_instance)
 
-    sse_transport = SseServerTransport("/messages/")
+    sse_transport = SseServerTransport("messages/")
     http_session_manager = StreamableHTTPSessionManager(
         app=mcp_server_instance,
         event_store=None,


### PR DESCRIPTION
Ref this comment https://github.com/sparfenyuk/mcp-proxy/pull/65#issuecomment-2886481196

The `messages` endpoint uses absolute path instead of relative path.

```
INFO:     127.0.0.1:65232 - "POST /messages/?session_id=dbe31c4ce2fb4111b37252aceb9d1ff0 HTTP/1.1" 404 Not Found
```

It should be `POST /servers/<server_name>/messages/`